### PR TITLE
Break up setsockopt support and its TCP options.

### DIFF
--- a/src/discover.ml
+++ b/src/discover.ml
@@ -310,10 +310,12 @@ let features =
     "TEE", L[ I "fcntl.h"; S"tee"; ];
     "VMSPLICE", L[ I "fcntl.h"; S"vmsplice"; ];
     "SOCKOPT", L[
-      I "sys/socket.h"; I "netinet/in.h"; I "netinet/tcp.h";
+      I "sys/socket.h"; I "netinet/in.h"; I"netinet/tcp.h";
       S"setsockopt"; S"getsockopt";
-      V"TCP_KEEPCNT"; V"TCP_KEEPIDLE"; V"TCP_KEEPINTVL";
     ];
+    "TCP_KEEPCNT", L[I"netinet/in.h"; I"netinet/tcp.h";V"TCP_KEEPCNT"];
+    "TCP_KEEPIDLE", L[I"netinet/in.h"; I"netinet/tcp.h";V"TCP_KEEPIDLE"];
+    "TCP_KEEPINTVL", L[I"netinet/in.h"; I"netinet/tcp.h";V"TCP_KEEPINTVL"];
     "POLL", L[ I "poll.h"; S "poll"; D "POLLIN"; D "POLLOUT"; Z "POLLRDHUP" ];
     "SYSINFO", L[ I"sys/sysinfo.h"; S"sysinfo"; F ("sysinfo","mem_unit")];
     "MCHECK", L[ I"mcheck.h"; S"mtrace"; S"muntrace" ];

--- a/src/extUnix.mlpp
+++ b/src/extUnix.mlpp
@@ -772,11 +772,22 @@ type socket_int_option =
                    keepalive probes, if the socket option SO_KEEPALIVE has been set on this socket *)
 | TCP_KEEPINTVL (** The time (in seconds) between individual keepalive probes *)
 
-(** Set an integer-valued option in the given socket *)
 external setsockopt_int : Unix.file_descr -> socket_int_option -> int -> unit = "caml_extunix_setsockopt_int"
+external getsockopt_int : Unix.file_descr -> socket_int_option -> int = "caml_extunix_getsockopt_int"
+
+(** Set an integer-valued option in the given socket *)
+let setsockopt_int sock opt v =
+  try
+    setsockopt_int sock opt v
+  with
+    Not_found -> raise (Not_available "setsockopt_int")
 
 (** Get the current value for the integer-valued option in the given socket *)
-external getsockopt_int : Unix.file_descr -> socket_int_option -> int = "caml_extunix_getsockopt_int"
+let getsockopt_int sock opt v =
+  try
+    getsockopt_int sock opt
+  with
+    Not_found -> raise (Not_available "getsockopt_int")
 
 END
 

--- a/src/sockopt.c
+++ b/src/sockopt.c
@@ -4,6 +4,20 @@
 
 #if defined(EXTUNIX_HAVE_SOCKOPT)
 
+#include <caml/fail.h>
+
+#ifndef TCP_KEEPCNT
+#define TCP_KEEPCNT -1
+#endif
+
+#ifndef TCP_KEEPIDLE
+#define TCP_KEEPIDLE -1
+#endif
+
+#ifndef TCP_KEEPINTVL
+#define TCP_KEEPINTVL -1
+#endif
+
 static int tcp_options[] = { 
   TCP_KEEPCNT, TCP_KEEPIDLE, TCP_KEEPINTVL,
 };
@@ -16,12 +30,16 @@ CAMLprim value caml_extunix_setsockopt_int(value fd, value k, value v)
   if (Int_val(k) < 0 || (unsigned int)Int_val(k) >= sizeof(tcp_options) / sizeof(tcp_options[0]))
     caml_invalid_argument("setsockopt_int");
 
-  if (0 != setsockopt(Int_val(fd), IPPROTO_TCP, tcp_options[Int_val(k)], &optval, optlen))
+  if (tcp_options[Int_val(k)] == -1)
   {
-    uerror("setsockopt_int", Nothing);
+    caml_raise_not_found();
+    return Val_unit;
   }
 
-  return Val_unit;
+  if (0 != setsockopt(Int_val(fd), IPPROTO_TCP, tcp_options[Int_val(k)], &optval, optlen))
+    uerror("setsockopt_int", Nothing);
+
+  return (Val_unit);
 }
 
 CAMLprim value caml_extunix_getsockopt_int(value fd, value k)
@@ -32,10 +50,14 @@ CAMLprim value caml_extunix_getsockopt_int(value fd, value k)
   if (Int_val(k) < 0 || (unsigned int)Int_val(k) >= sizeof(tcp_options) / sizeof(tcp_options[0]))
     caml_invalid_argument("getsockopt_int");
 
-  if (0 != getsockopt(Int_val(fd), IPPROTO_TCP, tcp_options[Int_val(k)], &optval, &optlen))
+  if (tcp_options[Int_val(k)] == -1)
   {
-    uerror("getsockopt_int", Nothing);
+    caml_raise_not_found();
+    return Val_unit;
   }
+
+  if (0 != getsockopt(Int_val(fd), IPPROTO_TCP, tcp_options[Int_val(k)], &optval, &optlen))
+    uerror("getsockopt_int", Nothing);
 
   return Val_int(optval);
 }


### PR DESCRIPTION
This makes sockopt available to OS X and very likely to other BSD systems, more
especifically, OS X does not have TCP_KEEPIDLE, but has all the others.

If we can't detect the TCP option, we define the value to -1, then we fake a
ENOPROTOOPT if the user passed an option defined to -1.

The risk, although virtually impossible, is that there is a unix system actually
using -1 to the value of those tcp options.

 checking VMSPLICE............failed
-checking SOCKOPT.............failed
+checking SOCKOPT.............ok
+checking TCP_KEEPCNT.........ok
+checking TCP_KEEPIDLE........failed
+checking TCP_KEEPINTVL.......ok
 checking POLL................ok