### PR TITLE
Add fchownat and fchmodat

### DIFF
--- a/src/atfile.c
+++ b/src/atfile.c
@@ -119,6 +119,28 @@ CAMLprim value caml_extunix_linkat(value v_olddirfd, value v_oldname, value v_ne
   CAMLreturn(Val_unit);
 }
 
+CAMLprim value caml_extunix_fchownat(value v_dirfd, value v_name, value v_owner, value v_group, value v_flags)
+{
+  CAMLparam5(v_dirfd, v_name, v_owner, v_group, v_flags);
+  int ret = 0;
+  int flags = caml_convert_flag_list(v_flags, at_flags_table);
+  flags &= (AT_SYMLINK_NOFOLLOW | AT_EMPTY_PATH);  /* only allowed flag here */
+  ret = fchownat(Int_val(v_dirfd), String_val(v_name), Int_val(v_owner), Int_val(v_group), flags);
+  if (ret != 0) uerror("fchownat", v_name);
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value caml_extunix_fchmodat(value v_dirfd, value v_name, value v_mode, value v_flags)
+{
+  CAMLparam4(v_dirfd, v_name, v_mode, v_flags);
+  int ret = 0;
+  int flags = caml_convert_flag_list(v_flags, at_flags_table);
+  flags &= AT_SYMLINK_NOFOLLOW;  /* only allowed flag here */
+  ret = fchmodat(Int_val(v_dirfd), String_val(v_name), Int_val(v_mode), flags);
+  if (ret != 0) uerror("fchmodat", v_name);
+  CAMLreturn(Val_unit);
+}
+
 CAMLprim value caml_extunix_symlinkat(value v_path, value v_newdirfd, value v_newname)
 {
   CAMLparam3(v_path, v_newdirfd, v_newname);

--- a/src/atfile.c
+++ b/src/atfile.c
@@ -95,7 +95,9 @@ CAMLprim value caml_extunix_unlinkat(value v_dirfd, value v_name, value v_flags)
 CAMLprim value caml_extunix_renameat(value v_oldfd, value v_oldname, value v_newfd, value v_newname)
 {
   CAMLparam4(v_oldfd, v_oldname, v_newfd, v_newname);
+  caml_enter_blocking_section();
   int ret = renameat(Int_val(v_oldfd), String_val(v_oldname), Int_val(v_newfd), String_val(v_newname));
+  caml_leave_blocking_section();
   if (ret != 0) uerror("renameat", v_oldname);
   CAMLreturn(Val_unit);
 }
@@ -103,7 +105,9 @@ CAMLprim value caml_extunix_renameat(value v_oldfd, value v_oldname, value v_new
 CAMLprim value caml_extunix_mkdirat(value v_dirfd, value v_name, value v_mode)
 {
   CAMLparam3(v_dirfd, v_name, v_mode);
+  caml_enter_blocking_section();
   int ret = mkdirat(Int_val(v_dirfd), String_val(v_name), Int_val(v_mode));
+  caml_leave_blocking_section();
   if (ret != 0) uerror("mkdirat", v_name);
   CAMLreturn(Val_unit);
 }
@@ -114,7 +118,9 @@ CAMLprim value caml_extunix_linkat(value v_olddirfd, value v_oldname, value v_ne
   int ret = 0;
   int flags = caml_convert_flag_list(v_flags, at_flags_table);
   flags &= AT_SYMLINK_FOLLOW;  /* only allowed flag here */
+  caml_enter_blocking_section();
   ret = linkat(Int_val(v_olddirfd), String_val(v_oldname), Int_val(v_newdirfd), String_val(v_newname), flags);
+  caml_leave_blocking_section();
   if (ret != 0) uerror("linkat", v_oldname);
   CAMLreturn(Val_unit);
 }
@@ -125,7 +131,9 @@ CAMLprim value caml_extunix_fchownat(value v_dirfd, value v_name, value v_owner,
   int ret = 0;
   int flags = caml_convert_flag_list(v_flags, at_flags_table);
   flags &= (AT_SYMLINK_NOFOLLOW | AT_EMPTY_PATH);  /* only allowed flag here */
+  caml_enter_blocking_section();
   ret = fchownat(Int_val(v_dirfd), String_val(v_name), Int_val(v_owner), Int_val(v_group), flags);
+  caml_leave_blocking_section();
   if (ret != 0) uerror("fchownat", v_name);
   CAMLreturn(Val_unit);
 }
@@ -136,7 +144,9 @@ CAMLprim value caml_extunix_fchmodat(value v_dirfd, value v_name, value v_mode, 
   int ret = 0;
   int flags = caml_convert_flag_list(v_flags, at_flags_table);
   flags &= AT_SYMLINK_NOFOLLOW;  /* only allowed flag here */
+  caml_enter_blocking_section();
   ret = fchmodat(Int_val(v_dirfd), String_val(v_name), Int_val(v_mode), flags);
+  caml_leave_blocking_section();
   if (ret != 0) uerror("fchmodat", v_name);
   CAMLreturn(Val_unit);
 }
@@ -144,7 +154,9 @@ CAMLprim value caml_extunix_fchmodat(value v_dirfd, value v_name, value v_mode, 
 CAMLprim value caml_extunix_symlinkat(value v_path, value v_newdirfd, value v_newname)
 {
   CAMLparam3(v_path, v_newdirfd, v_newname);
+  caml_enter_blocking_section();
   int ret = symlinkat(String_val(v_path), Int_val(v_newdirfd), String_val(v_newname));
+  caml_leave_blocking_section();
   if (ret != 0) uerror("symlinkat", v_path);
   CAMLreturn(Val_unit);
 }

--- a/src/discover.ml
+++ b/src/discover.ml
@@ -185,7 +185,7 @@ let features =
       I "sys/types.h"; I "sys/stat.h";
       I "unistd.h"; I "stdio.h";
       D "S_IFREG";
-      S "fstatat"; S "openat"; S "unlinkat"; S "renameat"; S "mkdirat"; S "linkat"; S "symlinkat"; S "readlinkat";
+      S "fstatat"; S "openat"; S "unlinkat"; S "renameat"; S "mkdirat"; S "linkat"; S "symlinkat"; S "readlinkat"; S "fchownat"; S "fchmodat";
     ];
     "DIRFD", L[
       I "sys/types.h";

--- a/src/extUnix.mlpp
+++ b/src/extUnix.mlpp
@@ -138,6 +138,8 @@ external mkdirat : Unix.file_descr -> string -> int -> unit = "caml_extunix_mkdi
 external linkat : Unix.file_descr -> string -> Unix.file_descr -> string -> at_flag list -> unit = "caml_extunix_linkat"
 external symlinkat : string -> Unix.file_descr -> string -> unit = "caml_extunix_symlinkat"
 external readlinkat : Unix.file_descr -> string -> string = "caml_extunix_readlinkat"
+external fchownat : Unix.file_descr -> string -> int -> int -> at_flag list -> unit = "caml_extunix_fchownat"
+external fchmodat : Unix.file_descr -> string -> int -> at_flag list -> unit = "caml_extunix_fchmodat"
 END
 
 (** @raise Not_available if OS does not represent file descriptors as numbers *)

--- a/test/test_user_namespace.ml
+++ b/test/test_user_namespace.ml
@@ -330,7 +330,7 @@ let create_rootfs ~distr ~release ~arch testdir =
         "tar Jxf %S -C %S --exclude-from %S \
          --numeric-owner --preserve-permissions --preserve-order --same-owner"
         rootfs rootfsdir exclude
-    else command_no_fail ~error "tar Jxf %S -C %S" meta metadir;
+    else command_no_fail ~error "tar Jxf %S -C %S" rootfs rootfsdir;
     Printf.printf "done.\n%!";
   end;
   rootfsdir


### PR DESCRIPTION
Add  fchownat and fchmodat in order to use these functions on a symlink using `AT_SYMLINK_NOFOLLOW`

Also add `caml_enter_blocking_section()`, `caml_leave_blocking_section()` around all the calls. I don't understand why that can be a good idea to not have them, and without them these functions can't be wrapped for use in lwt or async (using In_thread.syscall).