### PR TITLE
_oasis: use `-std=c99` for C files

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -43,7 +43,7 @@ Library extunix
   Path: src/
   Modules: ExtUnix, ExtUnixAll, ExtUnixSpecific, ExtUnixConfig
   if flag(strict) && ccomp_type(cc)
-    CCOpt: -std=c89 -pedantic -Wno-long-long -Wextra
+    CCOpt: -std=c99 -pedantic -Wno-long-long -Wextra
   CSources: config.h,
             eventfd.c, dirfd.c, fsync.c, statvfs.c, atfile.c,
             ioctl_siocgifconf.c, uname.c, fadvise.c, fallocate.c,


### PR DESCRIPTION
This proposal comes from #15.

I have not tested whether this fixes build.