### PR TITLE
Fix for 4.04

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -43,7 +43,7 @@ Library extunix
   Path: src/
   Modules: ExtUnix, ExtUnixAll, ExtUnixSpecific, ExtUnixConfig
   if flag(strict) && ccomp_type(cc)
-    CCOpt: -std=c89 -pedantic -Wno-long-long -Wextra
+    CCOpt: -pedantic -Wno-long-long -Wextra
   CSources: config.h,
             eventfd.c, dirfd.c, fsync.c, statvfs.c, atfile.c,
             ioctl_siocgifconf.c, uname.c, fadvise.c, fallocate.c,

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -620,8 +620,6 @@ let package_default =
                  S
                    [
                       A "-ccopt";
-                      A "-std=c89";
-                      A "-ccopt";
                       A "-pedantic";
                       A "-ccopt";
                       A "-Wno-long-long";

--- a/setup.ml
+++ b/setup.ml
@@ -7054,7 +7054,6 @@ let setup_t =
                               (OASISExpr.EFlag "strict",
                                 OASISExpr.ETest ("ccomp_type", "cc")),
                              [
-                                "-std=c89";
                                 "-pedantic";
                                 "-Wno-long-long";
                                 "-Wextra"


### PR DESCRIPTION
OCaml has moved to more modern versions of C, so the C89 option is too restrictive when you use OCaml's header files.
