### PR TITLE
Add IPv6 support to getifaddrs

### DIFF
--- a/src/discover.ml
+++ b/src/discover.ml
@@ -239,6 +239,10 @@ let features =
       I "arpa/inet.h";
       S "inet_ntoa";
     ];
+    "INET_NTOP", L[
+      I "arpa/inet.h";
+      S "inet_ntop";
+    ];
     "UNAME", L[
       I "sys/utsname.h";
       T "struct utsname";

--- a/src/extUnix.mlpp
+++ b/src/extUnix.mlpp
@@ -840,7 +840,7 @@ external uptime : unit -> int = "caml_extunix_uptime"
 
 [%%have IFADDRS
 
-(** @return the list of [PF_INET] interfaces and corresponding addresses ({b may change}) *)
+(** @return the list of [AF_INET] and [AF_INET6] interfaces and corresponding addresses ({b may change}) *)
 external getifaddrs : unit -> (string * string) list = "caml_extunix_getifaddrs"
 
 ]


### PR DESCRIPTION
This PR enables `getifaddrs` to return IPv6 addresses. `ntoa` is replaced by `ntop` and some simple handling is done to discriminate the addresses. I kept the `INET_NTOA` dependency because I have no way to test `siocgifconf` yet.