### PR TITLE
Enable network, endian, time related functions on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,7 @@ environment:
     # - OPAM_SWITCH: 4.07.1+msvc64c
 
 install:
+  - ps: (New-Object Net.WebClient).DownloadFile('https://cygwin.com/setup-x86_64.exe', "C:\cygwin64\setup-x86_64.exe")
   - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/$env:FORK_USER/ocaml-ci-scripts/$env:FORK_BRANCH/appveyor-install.ps1"))
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,6 @@
+image:
+  - Visual Studio 2019
+
 platform:
   - x64
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,18 +6,18 @@ environment:
   FORK_BRANCH: master
   CYG_ROOT: C:\cygwin64
   matrix:
-    - OPAM_SWITCH: 4.07.1+mingw64c
-    - OPAM_SWITCH: 4.08.1+mingw64c
-    - OPAM_SWITCH: 4.09.1+mingw64c
-    - OPAM_SWITCH: 4.10.2+mingw64c
-    - OPAM_SWITCH: 4.11.2+mingw64c
     - OPAM_SWITCH: 4.12.0+mingw64c
-    - OPAM_SWITCH: 4.07.1+msvc64c
-    - OPAM_SWITCH: 4.08.1+msvc64c
-    - OPAM_SWITCH: 4.09.1+msvc64c
-    - OPAM_SWITCH: 4.10.2+msvc64c
-    - OPAM_SWITCH: 4.11.2+msvc64c
     - OPAM_SWITCH: 4.12.0+msvc64c
+    # - OPAM_SWITCH: 4.11.2+mingw64c
+    # - OPAM_SWITCH: 4.11.2+msvc64c
+    # - OPAM_SWITCH: 4.10.2+mingw64c
+    # - OPAM_SWITCH: 4.10.2+msvc64c
+    # - OPAM_SWITCH: 4.09.1+mingw64c
+    # - OPAM_SWITCH: 4.09.1+msvc64c
+    # - OPAM_SWITCH: 4.08.1+mingw64c
+    # - OPAM_SWITCH: 4.08.1+msvc64c
+    # - OPAM_SWITCH: 4.07.1+mingw64c
+    # - OPAM_SWITCH: 4.07.1+msvc64c
 
 install:
   - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/$env:FORK_USER/ocaml-ci-scripts/$env:FORK_BRANCH/appveyor-install.ps1"))

--- a/discover/discover.ml
+++ b/discover/discover.ml
@@ -48,7 +48,7 @@ let config_defines = [
   "_DARWIN_C_SOURCE";
   "_LARGEFILE64_SOURCE";
   "WIN32_LEAN_AND_MEAN";
-  "_WIN32_WINNT 0x0600"; (* Vista *)
+  "_WIN32_WINNT 0x0602"; (* Windows 8 *)
   "CAML_NAME_SPACE";
   "_GNU_SOURCE"
   ]
@@ -329,10 +329,10 @@ let features =
       ];
       [
         DEFINE "EXTUNIX_USE_WINSOCK2_H";
-        I"winsock2.h"; I"sys/param.h";
+        I"winsock2.h";
         S"htons"; S"ntohs";
         S"htonl"; S"ntohl";
-        S"htonll"; S"ntohll";
+        (* S"htonll"; S"ntohll"; 2020-01-06: not supported by mingw-w64 yet *)
       ]
     ];
     "READ_CREDENTIALS", L[ fd_int; I"sys/types.h"; I"sys/socket.h"; D"SO_PEERCRED"; ];

--- a/discover/discover.ml
+++ b/discover/discover.ml
@@ -57,6 +57,9 @@ let config_defines = [
   ]
 
 let config_includes = [
+  "string.h";
+  "errno.h";
+  "assert.h";
   "caml/memory.h";
   "caml/fail.h";
   "caml/unixsupport.h";
@@ -64,9 +67,6 @@ let config_includes = [
   "caml/alloc.h";
   "caml/custom.h";
   "caml/bigarray.h";
-  "string.h";
-  "errno.h";
-  "assert.h";
   ]
 
 let build_code args =

--- a/src/dune
+++ b/src/dune
@@ -1,5 +1,5 @@
 (rule
- (targets config.h config.ml)
+ (targets config.h config.ml ldlibs.sexp)
  (deps
   (:gen ../discover/discover.exe))
  (action
@@ -22,6 +22,8 @@
     All)
    ((pps ppx_have)
     Specific)))
+ (c_library_flags
+  (:include ldlibs.sexp))
  (foreign_stubs
   (language c)
   (flags :standard)

--- a/src/endian_helper.h
+++ b/src/endian_helper.h
@@ -44,9 +44,14 @@ From https://gist.github.com/panzi/6856583
 #		define be32toh(x) ntohl(x)
 #		define le32toh(x) (x)
 
-#		define htobe64(x) htonll(x)
+#		if defined(__MINGW32__)
+#			define htobe64(x) __builtin_bswap64(x)
+#			define be64toh(x) __builtin_bswap64(x)
+#		else
+#			define htobe64(x) htonll(x)
+#			define be64toh(x) ntohll(x)
+#		endif
 #		define htole64(x) (x)
-#		define be64toh(x) ntohll(x)
 #		define le64toh(x) (x)
 
 #	elif BYTE_ORDER == BIG_ENDIAN

--- a/src/extUnix.pp.ml
+++ b/src/extUnix.pp.ml
@@ -1218,12 +1218,16 @@ external memalign: int -> int -> Bigarray.int8_unsigned_elt carray8 = "caml_extu
 
 (** {2 Time conversion} *)
 
-[%%have STRTIME
+[%%have STRPTIME
 
 (** This function is the converse of the {!strftime} function.
   [strptime fmt data] convert a string containing time information [data]
   into a [tm] struct according to the format specified by [fmt]. *)
 external strptime: string -> string -> Unix.tm = "caml_extunix_strptime"
+
+]
+
+[%%have STRTIME
 
 (** Return the ascii representation of a given [tm] argument. The
   ascii time is returned in the form of a string like
@@ -1231,7 +1235,7 @@ external strptime: string -> string -> Unix.tm = "caml_extunix_strptime"
 external asctime: Unix.tm -> string = "caml_extunix_asctime"
 
 (** This functions is the converse of the {!strptime} function.
-  [strftime fmt data] convert a a [tm] structure [data] into a string
+  [strftime fmt data] converts a [tm] structure [data] into a string
   according to the format specified by [fmt]. *)
 external strftime: string -> Unix.tm -> string = "caml_extunix_strftime"
 

--- a/src/malloc.c
+++ b/src/malloc.c
@@ -18,7 +18,6 @@ CAMLprim value caml_extunix_malloc_stats(value v_unit)
 #if defined(EXTUNIX_HAVE_MALLOC_INFO)
 
 #include <stdio.h>
-#include <memory.h>
 
 CAMLprim value caml_extunix_malloc_info(value v_unit)
 {

--- a/src/resource.c
+++ b/src/resource.c
@@ -31,8 +31,6 @@
 
 #if defined(EXTUNIX_HAVE_RESOURCE)
 
-#include <assert.h>
-
 static void decode_which_prio(value vwprio, int *pwhich, id_t *pwho)
 {
   CAMLparam1(vwprio);

--- a/src/sockopt.c
+++ b/src/sockopt.c
@@ -88,7 +88,11 @@ CAMLprim value caml_extunix_setsockopt_int(value fd, value k, value v)
 
   if (0 != setsockopt(Int_val(fd), tcp_options[Int_val(k)].level, tcp_options[Int_val(k)].opt, &optval, optlen))
   {
+#ifdef _WIN32
+    if (WSAGetLastError() == WSAENOPROTOOPT) {
+#else
     if (errno == ENOPROTOOPT) {
+#endif
       caml_raise_not_found();
       assert(0);
     }
@@ -116,7 +120,11 @@ CAMLprim value caml_extunix_getsockopt_int(value fd, value k)
 
   if (0 != getsockopt(Int_val(fd), tcp_options[Int_val(k)].level, tcp_options[Int_val(k)].opt, &optval, &optlen))
   {
+#ifdef _WIN32
+    if (WSAGetLastError() == WSAENOPROTOOPT) {
+#else
     if (errno == ENOPROTOOPT) {
+#endif
       caml_raise_not_found();
       assert(0);
     }

--- a/src/sockopt.c
+++ b/src/sockopt.c
@@ -3,9 +3,6 @@
 
 #if defined(EXTUNIX_HAVE_SOCKOPT)
 
-#include <assert.h>
-#include <errno.h>
-
 #ifndef TCP_KEEPCNT
 #define TCP_KEEPCNT (-1)
 #endif

--- a/src/sockopt.c
+++ b/src/sockopt.c
@@ -1,4 +1,3 @@
-
 #define EXTUNIX_WANT_SOCKOPT
 #include "config.h"
 
@@ -74,6 +73,14 @@ CAMLprim value caml_extunix_setsockopt_int(value fd, value k, value v)
 {
   int optval = Int_val(v);
   socklen_t optlen = sizeof(optval);
+#ifdef _WIN32
+  SOCKET s = INVALID_SOCKET;
+  if (KIND_SOCKET != Descr_kind_val(fd))
+    caml_invalid_argument("setsockopt_int");
+  s = Socket_val(fd);
+#else
+  int s = Int_val(fd);
+#endif
 
   if (Int_val(k) < 0 || (unsigned int)Int_val(k) >= sizeof(tcp_options) / sizeof(tcp_options[0]))
   {
@@ -86,7 +93,7 @@ CAMLprim value caml_extunix_setsockopt_int(value fd, value k, value v)
     assert(0);
   }
 
-  if (0 != setsockopt(Int_val(fd), tcp_options[Int_val(k)].level, tcp_options[Int_val(k)].opt, (void *)&optval, optlen))
+  if (0 != setsockopt(s, tcp_options[Int_val(k)].level, tcp_options[Int_val(k)].opt, (void *)&optval, optlen))
   {
 #ifdef _WIN32
     if (WSAGetLastError() == WSAENOPROTOOPT) {
@@ -106,6 +113,14 @@ CAMLprim value caml_extunix_getsockopt_int(value fd, value k)
 {
   int optval;
   socklen_t optlen = sizeof(optval);
+#ifdef _WIN32
+  SOCKET s = INVALID_SOCKET;
+  if (KIND_SOCKET != Descr_kind_val(fd))
+    caml_invalid_argument("getsockopt_int");
+  s = Socket_val(fd);
+#else
+  int s = Int_val(fd);
+#endif
 
   if (Int_val(k) < 0 || (unsigned int)Int_val(k) >= sizeof(tcp_options) / sizeof(tcp_options[0]))
   {
@@ -118,7 +133,7 @@ CAMLprim value caml_extunix_getsockopt_int(value fd, value k)
     assert(0);
   }
 
-  if (0 != getsockopt(Int_val(fd), tcp_options[Int_val(k)].level, tcp_options[Int_val(k)].opt, (void *)&optval, &optlen))
+  if (0 != getsockopt(s, tcp_options[Int_val(k)].level, tcp_options[Int_val(k)].opt, (void *)&optval, &optlen))
   {
 #ifdef _WIN32
     if (WSAGetLastError() == WSAENOPROTOOPT) {

--- a/src/sockopt.c
+++ b/src/sockopt.c
@@ -86,7 +86,7 @@ CAMLprim value caml_extunix_setsockopt_int(value fd, value k, value v)
     assert(0);
   }
 
-  if (0 != setsockopt(Int_val(fd), tcp_options[Int_val(k)].level, tcp_options[Int_val(k)].opt, &optval, optlen))
+  if (0 != setsockopt(Int_val(fd), tcp_options[Int_val(k)].level, tcp_options[Int_val(k)].opt, (void *)&optval, optlen))
   {
 #ifdef _WIN32
     if (WSAGetLastError() == WSAENOPROTOOPT) {
@@ -118,7 +118,7 @@ CAMLprim value caml_extunix_getsockopt_int(value fd, value k)
     assert(0);
   }
 
-  if (0 != getsockopt(Int_val(fd), tcp_options[Int_val(k)].level, tcp_options[Int_val(k)].opt, &optval, &optlen))
+  if (0 != getsockopt(Int_val(fd), tcp_options[Int_val(k)].level, tcp_options[Int_val(k)].opt, (void *)&optval, &optlen))
   {
 #ifdef _WIN32
     if (WSAGetLastError() == WSAENOPROTOOPT) {

--- a/src/syslog.c
+++ b/src/syslog.c
@@ -4,8 +4,6 @@
 
 #if defined(EXTUNIX_HAVE_SYSLOG)
 
-#include <assert.h>
-
 static int mask_table[] = {
   LOG_MASK(LOG_EMERG), LOG_MASK(LOG_ALERT), LOG_MASK(LOG_CRIT),
   LOG_MASK(LOG_ERR), LOG_MASK(LOG_WARNING), LOG_MASK(LOG_NOTICE),

--- a/src/time.c
+++ b/src/time.c
@@ -1,10 +1,11 @@
-
+#define EXTUNIX_WANT_STRPTIME
 #define EXTUNIX_WANT_STRTIME
 #define EXTUNIX_WANT_TIMEZONE
 #define EXTUNIX_WANT_TIMEGM
 #include "config.h"
 
-#if defined(EXTUNIX_HAVE_STRTIME)
+
+#if defined(EXTUNIX_HAVE_STRPTIME)
 
 /*
  * http://caml.inria.fr/mantis/view.php?id=3851
@@ -28,6 +29,22 @@ static value alloc_tm(struct tm *tm)
   return res;
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+
+CAMLprim value caml_extunix_strptime(value v_fmt, value v_s)
+{
+  struct tm tm = { 0 };
+  if (NULL == strptime(String_val(v_s),String_val(v_fmt),&tm))
+    unix_error(EINVAL, "strptime", v_s);
+  return alloc_tm(&tm);
+}
+
+#pragma GCC diagnostic pop
+#endif
+
+#if defined(EXTUNIX_HAVE_STRTIME) || defined(EXTUNIX_HAVE_TIMEGM)
+
 static void fill_tm(struct tm* tm, value t)
 {
   tm->tm_sec = Int_val(Field(t, 0));
@@ -41,47 +58,75 @@ static void fill_tm(struct tm* tm, value t)
   tm->tm_isdst = Bool_val(Field(t, 8)); /* -1 */
 }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
 
-CAMLprim value caml_extunix_strptime(value v_fmt, value v_s)
-{
-  struct tm tm = { 0 };
-  if (NULL == strptime(String_val(v_s),String_val(v_fmt),&tm))
-    unix_error(EINVAL, "strptime", v_s);
-  return alloc_tm(&tm);
-}
-
-#pragma GCC diagnostic pop
+#if defined(EXTUNIX_HAVE_STRTIME)
 
 CAMLprim value caml_extunix_asctime(value v_t)
 {
+  CAMLparam1(v_t);
   struct tm tm;
-  char buf[32]; /* user-supplied buffer which should have room for at least 26 bytes */
- 
+  char_os buf[32]; /* user-supplied buffer which should have room for
+                      at least 26 bytes */
+#if defined(_WIN32)
+  errno_t err;
+#endif
+
   fill_tm(&tm, v_t);
-  if (NULL == asctime_r(&tm,buf))
-    unix_error(EINVAL, "asctime", Nothing);
-  return caml_copy_string(buf);
+#if defined(_WIN32)
+  if ((0 != (err = _wasctime_s(buf, sizeof(buf)/sizeof(buf[0]), &tm)))) {
+    win32_maperr(err);
+#else
+  if (NULL == asctime_r(&tm, buf)) {
+#endif
+    uerror("asctime", Nothing);
+  }
+  CAMLreturn(caml_copy_string_of_os(buf));
 }
 
 CAMLprim value caml_extunix_strftime(value v_fmt, value v_t)
 {
+  CAMLparam2(v_fmt, v_t);
   struct tm tm;
-  char buf[256];
+  char_os buf[256];
+#if defined(_WIN32)
+  char_os *fmt;
+  size_t rc;
+#endif
 
   fill_tm(&tm, v_t);
+#if defined(_WIN32)
+  fmt = caml_stat_strdup_to_os(String_val(v_fmt));
+  rc = wcsftime(buf,sizeof(buf)/sizeof(buf[0]),fmt,&tm);
+  caml_stat_free(fmt);
+  if (0 == rc)
+#else
   if (0 == strftime(buf,sizeof(buf),String_val(v_fmt),&tm))
+#endif
     unix_error(EINVAL, "strftime", v_fmt);
 
-  return caml_copy_string(buf);
+  CAMLreturn(caml_copy_string_of_os(buf));
 }
 
 CAMLprim value caml_extunix_tzname(value v_isdst)
 {
+  CAMLparam1(v_isdst);
   int i = Bool_val(v_isdst) ? 1 : 0;
+#if defined(_WIN32)
+  CAMLlocal1(tzname);
+  size_t tznameSize;
+  _tzset();
+  if (0 != _get_tzname(&tznameSize, NULL, 0, i))
+    unix_error(EINVAL, "tzname", Nothing);
+  tzname = caml_alloc_string(tznameSize);
+  if (0 != _get_tzname(&tznameSize, (char *)String_val(tzname),
+                       tznameSize, i))
+    unix_error(EINVAL, "tzname", Nothing);
+  CAMLreturn(tzname);
+#else
   tzset();
-  return caml_copy_string(tzname[i]);
+  CAMLreturn(caml_copy_string(tzname[i]));
+#endif
 }
 
 #endif
@@ -92,9 +137,21 @@ CAMLprim value caml_extunix_timezone(value v_unit)
 {
   CAMLparam1(v_unit);
   CAMLlocal1(v);
+
+#if defined(_WIN32)
+  long timezone;
+  int daylight;
+  _tzset();
+  if (0 != _get_timezone(&timezone))
+    unix_error(EINVAL, "timezone", Nothing);
+  if (0 != _get_daylight(&daylight))
+    unix_error(EINVAL, "daylight", Nothing);
+#else
   tzset();
+#endif
+
   v = caml_alloc_tuple(2);
-  Store_field(v, 0, Val_int(timezone));
+  Store_field(v, 0, Val_long(timezone));
   Store_field(v, 1, Val_bool(daylight != 0));
   CAMLreturn(v);
 }
@@ -110,10 +167,13 @@ CAMLprim value caml_extunix_timegm(value v_t)
   time_t t;
 
   fill_tm(&tm, v_t);
+#if defined(_WIN32)
+  t = _mkgmtime(&tm);
+#else
   t = timegm(&tm);
+#endif
 
   CAMLreturn(caml_copy_double(t));
 }
 
 #endif
-


### PR DESCRIPTION
Some functions defined by ExtUnix are available on Windows. Let's enable their use!

This patch series tweaks the discover script to add definition of macros guarded by arbitrary conditions, and allows to pass library link flags to the compiler and pass the flag that were used to Dune. This is necessary form some functions that aren't in the default set of linked libraries on Windows, and could also help for other systems (Haiku, Solaris) which work also like this.