### PR TITLE
Support OCaml 5 new Unix API names

### DIFF
--- a/discover/discover.ml
+++ b/discover/discover.ml
@@ -80,6 +80,7 @@ let config_includes = [
   "caml/alloc.h";
   "caml/custom.h";
   "caml/bigarray.h";
+  "caml/version.h";
   ]
 
 let build_code args =

--- a/src/atfile.c
+++ b/src/atfile.c
@@ -5,7 +5,12 @@
 #if defined(EXTUNIX_HAVE_ATFILE)
 
 /* otherlibs/unix/cst2constr.h */
+#if OCAML_VERSION_MAJOR >= 5
+extern value caml_unix_cst_to_constr(int n, int * tbl, int size, int deflt);
+#else
 extern value cst_to_constr(int n, int * tbl, int size, int deflt);
+#define caml_unix_cst_to_constr cst_to_constr
+#endif
 
 static int file_kind_table[] = {
   S_IFREG, S_IFDIR, S_IFCHR, S_IFBLK, S_IFLNK, S_IFIFO, S_IFSOCK
@@ -43,8 +48,9 @@ static value stat_aux(/*int use_64,*/ struct stat *buf)
   v = caml_alloc_small(12, 0);
   Field (v, 0) = Val_int (buf->st_dev);
   Field (v, 1) = Val_int (buf->st_ino);
-  Field (v, 2) = cst_to_constr(buf->st_mode & S_IFMT, file_kind_table,
-                               sizeof(file_kind_table) / sizeof(int), 0);
+  Field (v, 2) =
+    caml_unix_cst_to_constr(buf->st_mode & S_IFMT, file_kind_table,
+                            sizeof(file_kind_table) / sizeof(int), 0);
   Field (v, 3) = Val_int (buf->st_mode & 07777);
   Field (v, 4) = Val_int (buf->st_nlink);
   Field (v, 5) = Val_int (buf->st_uid);


### PR DESCRIPTION
The compiler is considering ensuring all symbols in the Unix library are prefixed `caml_` for 5.0 (https://github.com/ocaml/ocaml/pull/10926).

extunix "steals" an undeclared API function - this adds the required test with `caml/version.h` to select the correct name for it.