### PR TITLE
Add renameat2

### DIFF
--- a/discover/discover.ml
+++ b/discover/discover.ml
@@ -232,7 +232,6 @@ let features =
     ];
     "RENAMEAT2", L[
       fd_int;
-      DEFINE "_GNU_SOURCE";
       I "fcntl.h"; I "stdio.h";
       S "renameat2";
     ];

--- a/discover/discover.ml
+++ b/discover/discover.ml
@@ -229,6 +229,12 @@ let features =
       D "S_IFREG";
       S "fstatat"; S "openat"; S "unlinkat"; S "renameat"; S "mkdirat"; S "linkat"; S "symlinkat"; S "readlinkat"; S "fchownat"; S "fchmodat";
     ];
+    "RENAMEAT2", L[
+      fd_int;
+      DEFINE "_GNU_SOURCE";
+      I "fcntl.h"; I "stdio.h";
+      S "renameat2";
+    ];
     "DIRFD", L[
       fd_int;
       I "sys/types.h";

--- a/discover/discover.ml
+++ b/discover/discover.ml
@@ -78,6 +78,7 @@ let config_includes = [
   "caml/unixsupport.h";
   "caml/signals.h";
   "caml/alloc.h";
+  "caml/callback.h";
   "caml/custom.h";
   "caml/bigarray.h";
   "caml/version.h";
@@ -234,6 +235,10 @@ let features =
       DEFINE "_GNU_SOURCE";
       I "fcntl.h"; I "stdio.h";
       S "renameat2";
+    ];
+    "RENAME_WHITEOUT", L[
+      DEFINE "_GNU_SOURCE";
+      D "RENAME_WHITEOUT";
     ];
     "DIRFD", L[
       fd_int;

--- a/src/dune
+++ b/src/dune
@@ -51,6 +51,7 @@
    pts
    read_cred
    realpath
+   rename
    resource
    sendmsg
    signalfd

--- a/src/extUnix.pp.ml
+++ b/src/extUnix.pp.ml
@@ -13,6 +13,8 @@ the corresponding man pages and/or system documentation for details.
     [ENOSYS] (Not implemented) error even though the function is available. *)
 exception Not_available of string
 
+let _ = Callback.register_exception "ExtUnix.Not_available" (Not_available "")
+
 (** type of bigarray used by BA submodules that read from files into
     bigarrays or write bigarrays into files.  The only constraint here
     is [Bigarray.c_layout].
@@ -212,7 +214,7 @@ external fchmodat : Unix.file_descr -> string -> int -> at_flag list -> unit = "
 ]
 
 [%%have RENAMEAT2
-type rename_flag = RENAME_EXCHANGE | RENAME_NOREPLACE | RENAME_WHITEOUT
+type rename_flag = RENAME_EXCHANGE | RENAME_NOREPLACE | RENAME_WHITEOUT [@have RENAME_WHITEOUT]
 
 external renameat2 : Unix.file_descr -> string -> Unix.file_descr -> string -> rename_flag list -> unit = "caml_extunix_renameat2"
 ]

--- a/src/extUnix.pp.ml
+++ b/src/extUnix.pp.ml
@@ -211,6 +211,12 @@ external fchownat : Unix.file_descr -> string -> int -> int -> at_flag list -> u
 external fchmodat : Unix.file_descr -> string -> int -> at_flag list -> unit = "caml_extunix_fchmodat"
 ]
 
+[%%have RENAMEAT2
+type rename_flag = RENAME_EXCHANGE | RENAME_NOREPLACE | RENAME_WHITEOUT
+
+external renameat2 : Unix.file_descr -> string -> Unix.file_descr -> string -> rename_flag list -> unit = "caml_extunix_renameat2"
+]
+
 (** @raise Not_available if OS does not represent file descriptors as numbers *)
 let int_of_file_descr : Unix.file_descr -> int =
   if Obj.is_block (Obj.repr Unix.stdin) then

--- a/src/rename.c
+++ b/src/rename.c
@@ -31,11 +31,14 @@ CAMLprim value caml_extunix_renameat2(value v_oldfd, value v_oldname, value v_ne
   CAMLparam5(v_oldfd, v_oldname, v_newfd, v_newname, v_flags);
   check_flag_list(v_flags);
   int oldfd = Int_val(v_oldfd), newfd = Int_val(v_newfd);
-  const char *oldname = String_val(v_oldname), *newname = String_val(v_newname);
+  const char *oldname = caml_stat_strdup(String_val(v_oldname)),
+             *newname = caml_stat_strdup(String_val(v_newname));
   int flags = caml_convert_flag_list(v_flags, rename_flags_table);
   caml_enter_blocking_section();
   int ret = renameat2(oldfd, oldname, newfd, newname, flags);
   caml_leave_blocking_section();
+  caml_stat_free(oldname);
+  caml_stat_free(newname);
   if (ret != 0) uerror("renameat2", v_oldname);
   CAMLreturn(Val_unit);
 }

--- a/src/rename.c
+++ b/src/rename.c
@@ -1,0 +1,25 @@
+
+#define EXTUNIX_WANT_RENAMEAT2
+#include "config.h"
+
+#if defined(EXTUNIX_HAVE_RENAMEAT2)
+
+#ifndef RENAME_WHITEOUT
+#define RENAME_WHITEOUT 0
+#endif
+
+static int rename_flags_table[] = {
+  RENAME_NOREPLACE, RENAME_EXCHANGE, RENAME_WHITEOUT,
+};
+
+CAMLprim value caml_extunix_renameat2(value v_oldfd, value v_oldname, value v_newfd, value v_newname, value v_flags)
+{
+  CAMLparam5(v_oldfd, v_oldname, v_newfd, v_newname, v_flags);
+  int flags = caml_convert_flag_list(v_flags, rename_flags_table);
+  caml_enter_blocking_section();
+  int ret = renameat2(Int_val(v_oldfd), String_val(v_oldname), Int_val(v_newfd), String_val(v_newname), flags);
+  caml_leave_blocking_section();
+  if (ret != 0) uerror("renameat2", v_oldname);
+  CAMLreturn(Val_unit);
+}
+#endif

--- a/src/rename.c
+++ b/src/rename.c
@@ -1,4 +1,3 @@
-
 #define EXTUNIX_WANT_RENAMEAT2
 #include "config.h"
 
@@ -8,7 +7,7 @@
 #define RENAME_WHITEOUT 0
 #endif
 
-static int rename_flags_table[] = {
+static const int rename_flags_table[] = {
   RENAME_NOREPLACE, /* 0 */
   RENAME_EXCHANGE, /* 1 */
   RENAME_WHITEOUT, /* 2 */
@@ -16,7 +15,7 @@ static int rename_flags_table[] = {
 
 #define RENAME_WHITEOUT_INDEX 2
 
-void caml_check_flag_list(value list)
+static void check_flag_list(value list)
 {
   for (/*nothing*/; list != Val_emptylist; list = Field(list, 1))
   {
@@ -30,7 +29,7 @@ void caml_check_flag_list(value list)
 CAMLprim value caml_extunix_renameat2(value v_oldfd, value v_oldname, value v_newfd, value v_newname, value v_flags)
 {
   CAMLparam5(v_oldfd, v_oldname, v_newfd, v_newname, v_flags);
-  caml_check_flag_list(v_flags);
+  check_flag_list(v_flags);
   int flags = caml_convert_flag_list(v_flags, rename_flags_table);
   caml_enter_blocking_section();
   int ret = renameat2(Int_val(v_oldfd), String_val(v_oldname), Int_val(v_newfd), String_val(v_newname), flags);

--- a/src/rename.c
+++ b/src/rename.c
@@ -30,9 +30,11 @@ CAMLprim value caml_extunix_renameat2(value v_oldfd, value v_oldname, value v_ne
 {
   CAMLparam5(v_oldfd, v_oldname, v_newfd, v_newname, v_flags);
   check_flag_list(v_flags);
+  int oldfd = Int_val(v_oldfd), newfd = Int_val(v_newfd);
+  const char *oldname = String_val(v_oldname), *newname = String_val(v_newname);
   int flags = caml_convert_flag_list(v_flags, rename_flags_table);
   caml_enter_blocking_section();
-  int ret = renameat2(Int_val(v_oldfd), String_val(v_oldname), Int_val(v_newfd), String_val(v_newname), flags);
+  int ret = renameat2(oldfd, oldname, newfd, newname, flags);
   caml_leave_blocking_section();
   if (ret != 0) uerror("renameat2", v_oldname);
   CAMLreturn(Val_unit);

--- a/src/rename.c
+++ b/src/rename.c
@@ -9,12 +9,28 @@
 #endif
 
 static int rename_flags_table[] = {
-  RENAME_NOREPLACE, RENAME_EXCHANGE, RENAME_WHITEOUT,
+  RENAME_NOREPLACE, /* 0 */
+  RENAME_EXCHANGE, /* 1 */
+  RENAME_WHITEOUT, /* 2 */
 };
+
+#define RENAME_WHITEOUT_INDEX 2
+
+void caml_check_flag_list(value list)
+{
+  for (/*nothing*/; list != Val_emptylist; list = Field(list, 1))
+  {
+#if !defined(EXTUNIX_HAVE_RENAME_WHITEOUT)
+    if (RENAME_WHITEOUT_INDEX == Int_val(Field(list, 0)))
+      caml_raise_with_string(*caml_named_value("ExtUnix.Not_available"), "renameat2 RENAME_WHITEOUT");
+#endif
+  }
+}
 
 CAMLprim value caml_extunix_renameat2(value v_oldfd, value v_oldname, value v_newfd, value v_newname, value v_flags)
 {
   CAMLparam5(v_oldfd, v_oldname, v_newfd, v_newname, v_flags);
+  caml_check_flag_list(v_flags);
   int flags = caml_convert_flag_list(v_flags, rename_flags_table);
   caml_enter_blocking_section();
   int ret = renameat2(Int_val(v_oldfd), String_val(v_oldname), Int_val(v_newfd), String_val(v_newname), flags);


### PR DESCRIPTION
- add renameat2 function and flags
- suffix constructors marked with `[@have <feature>]` with `__Not_available` if  <feature> is not available.
- register `ExtUnix.Not_available` with C runtime so it's possible to raise `Not_available` from bindings