### PR TITLE
Add TIOCGWINSZ

### DIFF
--- a/discover/discover.ml
+++ b/discover/discover.ml
@@ -281,8 +281,9 @@ let features =
     "TTY_IOCTL", L[
       fd_int;
       I "termios.h"; I "sys/ioctl.h";
+      T "struct winsize";
       S "ioctl"; S "tcsetattr"; S "tcgetattr";
-      D "CRTSCTS"; D "TCSANOW"; D "TIOCMGET"; D "TIOCMSET"; D "TIOCMBIC"; D "TIOCMBIS";
+      D "CRTSCTS"; D "TCSANOW"; D "TIOCMGET"; D "TIOCMSET"; D "TIOCMBIC"; D "TIOCMBIS"; D "TIOCGWINSZ"
     ];
     "TTYNAME", L[ fd_int; I "unistd.h"; S "ttyname"; ];
     "CTERMID", L[ I "stdio.h"; S "ctermid"; V "L_ctermid"; ];

--- a/dune-project
+++ b/dune-project
@@ -38,6 +38,7 @@
   "Roman Vorobets"
   "Stéphane Glondu"
   "Sylvain Le Gall"
+  "Teague Hansen"
   "ygrek"
   "Zhenya Lykhovyd"
  )

--- a/extunix.opam
+++ b/extunix.opam
@@ -25,6 +25,7 @@ authors: [
   "Roman Vorobets"
   "Stéphane Glondu"
   "Sylvain Le Gall"
+  "Teague Hansen"
   "ygrek"
   "Zhenya Lykhovyd"
 ]

--- a/src/extUnix.pp.ml
+++ b/src/extUnix.pp.ml
@@ -795,7 +795,7 @@ external tiocmbis : Unix.file_descr -> int -> unit = "caml_extunix_ioctl_TIOCMBI
 
 (** [tiocgwinsz fd] returns a tuple [(cols, rows, xpixel, ypixel)] representing
     the size of the character device. [cols] is the number of character columns,
-    [rows] is the number of character rows, [xpixel] is width of the device in 
+    [rows] is the number of character rows, [xpixel] is width of the device in
     pixels, and [ypixel] is the height of the device in pixels. *)
 external tiocgwinsz : Unix.file_descr -> (int * int * int * int) = "caml_extunix_ioctl_TIOCGWINSZ"
 

--- a/src/extUnix.pp.ml
+++ b/src/extUnix.pp.ml
@@ -793,6 +793,9 @@ external tiocmbic : Unix.file_descr -> int -> unit = "caml_extunix_ioctl_TIOCMBI
 (** Set the indicated modem bits. See TIOCMBIS in tty_ioctl(4). *)
 external tiocmbis : Unix.file_descr -> int -> unit = "caml_extunix_ioctl_TIOCMBIS"
 
+(* Get the size of a character device. See TIOCGWINSZ in tty_ioctl(4). *)
+external tiocgwinsz : Unix.file_descr -> (int * int) = "caml_extunix_ioctl_TIOCGWINSZ"
+
 ]
 
 end (* module Ioctl *)

--- a/src/extUnix.pp.ml
+++ b/src/extUnix.pp.ml
@@ -793,8 +793,11 @@ external tiocmbic : Unix.file_descr -> int -> unit = "caml_extunix_ioctl_TIOCMBI
 (** Set the indicated modem bits. See TIOCMBIS in tty_ioctl(4). *)
 external tiocmbis : Unix.file_descr -> int -> unit = "caml_extunix_ioctl_TIOCMBIS"
 
-(* Get the size of a character device. See TIOCGWINSZ in tty_ioctl(4). *)
-external tiocgwinsz : Unix.file_descr -> (int * int) = "caml_extunix_ioctl_TIOCGWINSZ"
+(** [tiocgwinsz fd] returns a tuple [(cols, rows, xpixel, ypixel)] representing
+    the size of the character device. [cols] is the number of character columns,
+    [rows] is the number of character rows, [xpixel] is width of the device in 
+    pixels, and [ypixel] is the height of the device in pixels. *)
+external tiocgwinsz : Unix.file_descr -> (int * int * int * int) = "caml_extunix_ioctl_TIOCGWINSZ"
 
 ]
 

--- a/src/tty_ioctl.c
+++ b/src/tty_ioctl.c
@@ -33,7 +33,7 @@ CAMLprim value caml_extunix_ioctl_##cmd(value v_fd, value v_arg) \
   CAMLreturn(Val_unit); \
 }
 
-CAMLprim value caml_extunix_ioctl_TIOCGWINSZ(value v_fd) 
+CAMLprim value caml_extunix_ioctl_TIOCGWINSZ(value v_fd)
 {
     CAMLparam1(v_fd);
     CAMLlocal1(result);
@@ -45,7 +45,7 @@ CAMLprim value caml_extunix_ioctl_TIOCGWINSZ(value v_fd)
         uerror("ioctl", caml_copy_string("TIOCGWINSZ"));
     }
 
-    result = caml_alloc(4, 0);
+    result = caml_alloc_tuple(4);
     Store_field(result, 0, Val_int(ws.ws_col));
     Store_field(result, 1, Val_int(ws.ws_row));
     Store_field(result, 2, Val_int(ws.ws_xpixel));
@@ -68,4 +68,3 @@ TTY_IOCTL_INT(TIOCMBIC)
 TTY_IOCTL_INT(TIOCMBIS)
 
 #endif
-

--- a/src/tty_ioctl.c
+++ b/src/tty_ioctl.c
@@ -45,9 +45,11 @@ CAMLprim value caml_extunix_ioctl_TIOCGWINSZ(value v_fd)
         uerror("ioctl", caml_copy_string("TIOCGWINSZ"));
     }
 
-    result = caml_alloc(2, 0);
+    result = caml_alloc(4, 0);
     Store_field(result, 0, Val_int(ws.ws_col));
     Store_field(result, 1, Val_int(ws.ws_row));
+    Store_field(result, 2, Val_int(ws.ws_xpixel));
+    Store_field(result, 3, Val_int(ws.ws_ypixel));
 
     CAMLreturn(result);
 }

--- a/src/tty_ioctl.c
+++ b/src/tty_ioctl.c
@@ -33,6 +33,25 @@ CAMLprim value caml_extunix_ioctl_##cmd(value v_fd, value v_arg) \
   CAMLreturn(Val_unit); \
 }
 
+CAMLprim value caml_extunix_ioctl_TIOCGWINSZ(value v_fd) 
+{
+    CAMLparam1(v_fd);
+    CAMLlocal1(result);
+
+    struct winsize ws;
+
+    int r = ioctl(Int_val(v_fd), TIOCGWINSZ, &ws);
+    if (r < 0) {
+        uerror("ioctl", caml_copy_string("TIOCGWINSZ"));
+    }
+
+    result = caml_alloc(2, 0);
+    Store_field(result, 0, Val_int(ws.ws_col));
+    Store_field(result, 1, Val_int(ws.ws_row));
+
+    CAMLreturn(result);
+}
+
 CAMLprim value caml_extunix_ioctl_TIOCMGET(value v_fd)
 {
   CAMLparam1(v_fd);


### PR DESCRIPTION
Add function `tiocgwinsz` to [tty_ioctl](https://github.com/H-ANSEN/extunix/blob/master/src/tty_ioctl.c) module, allowing for the retrieval of character width and height, as well as pixel width and height of a given tty device.

Note automated tests cannot be reliably implemented for this but local tests verified functionality!