### PR TITLE
Memory fixes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+## unreleased
+* Move macros accessing values outside of blocking sections
+
 ## v0.4.2 - 10 Aug 2024
 * Add TIOCGWINSZ ioctl
 * Release runtime mutex in all functions in atfile.c

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 ## unreleased
 * Move macros accessing values outside of blocking sections
+* Use caml_stat_* functions instead of malloc/free for heap data
 
 ## v0.4.2 - 10 Aug 2024
 * Add TIOCGWINSZ ioctl

--- a/src/atfile.c
+++ b/src/atfile.c
@@ -1,4 +1,3 @@
-
 #define EXTUNIX_WANT_ATFILE
 #include "config.h"
 
@@ -71,13 +70,14 @@ CAMLprim value caml_extunix_fstatat(value v_dirfd, value v_name, value v_flags)
 {
   CAMLparam3(v_dirfd, v_name, v_flags);
   int ret;
+  int dirfd = Int_val(v_dirfd);
   struct stat buf;
   char* p = strdup(String_val(v_name));
   int flags = caml_convert_flag_list(v_flags, at_flags_table);
   flags &= (AT_SYMLINK_NOFOLLOW | AT_NO_AUTOMOUNT); /* only allowed flags here */
 
   caml_enter_blocking_section();
-  ret = fstatat(Int_val(v_dirfd), p, &buf, flags);
+  ret = fstatat(dirfd, p, &buf, flags);
   caml_leave_blocking_section();
   free(p);
   if (ret != 0) uerror("fstatat", v_name);
@@ -89,13 +89,14 @@ CAMLprim value caml_extunix_fstatat(value v_dirfd, value v_name, value v_flags)
 CAMLprim value caml_extunix_unlinkat(value v_dirfd, value v_name, value v_flags)
 {
   CAMLparam3(v_dirfd, v_name, v_flags);
+  int dirfd = Int_val(dirfd);
   char* p = strdup(String_val(v_name));
   int ret = 0;
   int flags = caml_convert_flag_list(v_flags, at_flags_table);
   flags &= AT_REMOVEDIR;  /* only allowed flag here */
 
   caml_enter_blocking_section();
-  ret = unlinkat(Int_val(v_dirfd), p, flags);
+  ret = unlinkat(dirfd, p, flags);
   caml_leave_blocking_section();
   free(p);
   if (ret != 0) uerror("unlinkat", v_name);
@@ -105,8 +106,10 @@ CAMLprim value caml_extunix_unlinkat(value v_dirfd, value v_name, value v_flags)
 CAMLprim value caml_extunix_renameat(value v_oldfd, value v_oldname, value v_newfd, value v_newname)
 {
   CAMLparam4(v_oldfd, v_oldname, v_newfd, v_newname);
+  int oldfd = Int_val(v_oldfd), newfd = Int_val(newfd);
+  const char *oldname = String_val(v_oldname), *newname = String_val(v_newname);
   caml_enter_blocking_section();
-  int ret = renameat(Int_val(v_oldfd), String_val(v_oldname), Int_val(v_newfd), String_val(v_newname));
+  int ret = renameat(oldfd, oldname, newfd, newname);
   caml_leave_blocking_section();
   if (ret != 0) uerror("renameat", v_oldname);
   CAMLreturn(Val_unit);
@@ -115,8 +118,10 @@ CAMLprim value caml_extunix_renameat(value v_oldfd, value v_oldname, value v_new
 CAMLprim value caml_extunix_mkdirat(value v_dirfd, value v_name, value v_mode)
 {
   CAMLparam3(v_dirfd, v_name, v_mode);
+  int dirfd = Int_val(v_dirfd), mode = Int_val(v_mode);
+  const char *name = String_val(v_name);
   caml_enter_blocking_section();
-  int ret = mkdirat(Int_val(v_dirfd), String_val(v_name), Int_val(v_mode));
+  int ret = mkdirat(dirfd, name, mode);
   caml_leave_blocking_section();
   if (ret != 0) uerror("mkdirat", v_name);
   CAMLreturn(Val_unit);
@@ -125,11 +130,13 @@ CAMLprim value caml_extunix_mkdirat(value v_dirfd, value v_name, value v_mode)
 CAMLprim value caml_extunix_linkat(value v_olddirfd, value v_oldname, value v_newdirfd, value v_newname, value v_flags)
 {
   CAMLparam5(v_olddirfd, v_oldname, v_newdirfd, v_newname, v_flags);
+  int olddirfd = Int_val(v_olddirfd), newdirfd = Int_val(v_newdirfd);
+  const char *oldname = String_val(v_oldname), *newname = String_val(v_newname);
   int ret = 0;
   int flags = caml_convert_flag_list(v_flags, at_flags_table);
   flags &= AT_SYMLINK_FOLLOW;  /* only allowed flag here */
   caml_enter_blocking_section();
-  ret = linkat(Int_val(v_olddirfd), String_val(v_oldname), Int_val(v_newdirfd), String_val(v_newname), flags);
+  ret = linkat(olddirfd, oldname, newdirfd, newname, flags);
   caml_leave_blocking_section();
   if (ret != 0) uerror("linkat", v_oldname);
   CAMLreturn(Val_unit);
@@ -138,11 +145,13 @@ CAMLprim value caml_extunix_linkat(value v_olddirfd, value v_oldname, value v_ne
 CAMLprim value caml_extunix_fchownat(value v_dirfd, value v_name, value v_owner, value v_group, value v_flags)
 {
   CAMLparam5(v_dirfd, v_name, v_owner, v_group, v_flags);
+  int dirfd = Int_val(v_dirfd), owner = Int_val(v_owner), group = Int_val(v_group);
+  const char *name = String_val(v_name);
   int ret = 0;
   int flags = caml_convert_flag_list(v_flags, at_flags_table);
   flags &= (AT_SYMLINK_NOFOLLOW /* | AT_EMPTY_PATH */);  /* only allowed flag here */
   caml_enter_blocking_section();
-  ret = fchownat(Int_val(v_dirfd), String_val(v_name), Int_val(v_owner), Int_val(v_group), flags);
+  ret = fchownat(dirfd, name, owner, group, flags);
   caml_leave_blocking_section();
   if (ret != 0) uerror("fchownat", v_name);
   CAMLreturn(Val_unit);
@@ -151,11 +160,13 @@ CAMLprim value caml_extunix_fchownat(value v_dirfd, value v_name, value v_owner,
 CAMLprim value caml_extunix_fchmodat(value v_dirfd, value v_name, value v_mode, value v_flags)
 {
   CAMLparam4(v_dirfd, v_name, v_mode, v_flags);
+  int dirfd = Int_val(v_dirfd), mode = Int_val(v_mode);
+  const char *name = String_val(v_name);
   int ret = 0;
   int flags = caml_convert_flag_list(v_flags, at_flags_table);
   flags &= AT_SYMLINK_NOFOLLOW;  /* only allowed flag here */
   caml_enter_blocking_section();
-  ret = fchmodat(Int_val(v_dirfd), String_val(v_name), Int_val(v_mode), flags);
+  ret = fchmodat(dirfd, name, mode, flags);
   caml_leave_blocking_section();
   if (ret != 0) uerror("fchmodat", v_name);
   CAMLreturn(Val_unit);
@@ -164,16 +175,19 @@ CAMLprim value caml_extunix_fchmodat(value v_dirfd, value v_name, value v_mode, 
 CAMLprim value caml_extunix_symlinkat(value v_path, value v_newdirfd, value v_newname)
 {
   CAMLparam3(v_path, v_newdirfd, v_newname);
+  const char *path = String_val(v_path), *newname = String_val(v_newname);
+  int newdirfd = Int_val(v_newdirfd);
   caml_enter_blocking_section();
-  int ret = symlinkat(String_val(v_path), Int_val(v_newdirfd), String_val(v_newname));
+  int ret = symlinkat(path, newdirfd, newname);
   caml_leave_blocking_section();
   if (ret != 0) uerror("symlinkat", v_path);
   CAMLreturn(Val_unit);
 }
 
-CAMLprim value caml_extunix_openat(value v_dirfd, value path, value flags, value perm)
+CAMLprim value caml_extunix_openat(value v_dirfd, value path, value flags, value v_perm)
 {
-  CAMLparam4(v_dirfd, path, flags, perm);
+  CAMLparam4(v_dirfd, path, flags, v_perm);
+  int dirfd = Int_val(v_dirfd), perm = Int_val(v_perm);
   int ret, cv_flags;
   char * p;
 
@@ -181,7 +195,7 @@ CAMLprim value caml_extunix_openat(value v_dirfd, value path, value flags, value
   p = strdup(String_val(path));
   /* open on a named FIFO can block (PR#1533) */
   caml_enter_blocking_section();
-  ret = openat(Int_val(v_dirfd), p, cv_flags, Int_val(perm));
+  ret = openat(dirfd, p, cv_flags, perm);
   caml_leave_blocking_section();
   free(p);
   if (ret == -1) uerror("openat", path);
@@ -223,11 +237,12 @@ CAMLprim value caml_extunix_readlinkat(value v_dirfd, value v_name)
 {
   CAMLparam2(v_dirfd, v_name);
   CAMLlocal1(v_link);
+  int dirfd = Int_val(v_dirfd);
   char* res;
   char* p = strdup(String_val(v_name));
 
   caml_enter_blocking_section();
-  res = readlinkat_malloc(Int_val(v_dirfd), p);
+  res = readlinkat_malloc(dirfd, p);
   caml_leave_blocking_section();
   free(p);
   if (res == NULL) uerror("readlinkat", v_name);
@@ -237,4 +252,3 @@ CAMLprim value caml_extunix_readlinkat(value v_dirfd, value v_name)
 }
 
 #endif
-

--- a/src/atfile.c
+++ b/src/atfile.c
@@ -72,14 +72,14 @@ CAMLprim value caml_extunix_fstatat(value v_dirfd, value v_name, value v_flags)
   int ret;
   int dirfd = Int_val(v_dirfd);
   struct stat buf;
-  char* p = strdup(String_val(v_name));
+  char* p = caml_stat_strdup(String_val(v_name));
   int flags = caml_convert_flag_list(v_flags, at_flags_table);
   flags &= (AT_SYMLINK_NOFOLLOW | AT_NO_AUTOMOUNT); /* only allowed flags here */
 
   caml_enter_blocking_section();
   ret = fstatat(dirfd, p, &buf, flags);
   caml_leave_blocking_section();
-  free(p);
+  caml_stat_free(p);
   if (ret != 0) uerror("fstatat", v_name);
   if (buf.st_size > Max_long && (buf.st_mode & S_IFMT) == S_IFREG)
     unix_error(EOVERFLOW, "fstatat", v_name);
@@ -90,7 +90,7 @@ CAMLprim value caml_extunix_unlinkat(value v_dirfd, value v_name, value v_flags)
 {
   CAMLparam3(v_dirfd, v_name, v_flags);
   int dirfd = Int_val(dirfd);
-  char* p = strdup(String_val(v_name));
+  char* p = caml_stat_strdup(String_val(v_name));
   int ret = 0;
   int flags = caml_convert_flag_list(v_flags, at_flags_table);
   flags &= AT_REMOVEDIR;  /* only allowed flag here */
@@ -98,7 +98,7 @@ CAMLprim value caml_extunix_unlinkat(value v_dirfd, value v_name, value v_flags)
   caml_enter_blocking_section();
   ret = unlinkat(dirfd, p, flags);
   caml_leave_blocking_section();
-  free(p);
+  caml_stat_free(p);
   if (ret != 0) uerror("unlinkat", v_name);
   CAMLreturn(Val_unit);
 }
@@ -192,12 +192,12 @@ CAMLprim value caml_extunix_openat(value v_dirfd, value path, value flags, value
   char * p;
 
   cv_flags = extunix_open_flags(flags);
-  p = strdup(String_val(path));
+  p = caml_stat_strdup(String_val(path));
   /* open on a named FIFO can block (PR#1533) */
   caml_enter_blocking_section();
   ret = openat(dirfd, p, cv_flags, perm);
   caml_leave_blocking_section();
-  free(p);
+  caml_stat_free(p);
   if (ret == -1) uerror("openat", path);
   CAMLreturn (Val_int(ret));
 }
@@ -211,17 +211,17 @@ char *readlinkat_malloc (int dirfd, const char *filename)
 
   while (1)
     {
-      tmp = (char *) realloc (buffer, size);
+      tmp = caml_stat_resize_noexc (buffer, size);
       if (tmp == NULL)
       {
-        free(buffer); /* if failed, dealloc is not performed */
+        caml_stat_free (buffer); /* if failed, dealloc is not performed */
         return NULL;
       }
       buffer = tmp;
       nchars = readlinkat (dirfd, filename, buffer, size);
       if (nchars < 0)
       {
-          free (buffer);
+          caml_stat_free (buffer);
           return NULL;
       }
       if (nchars < size)
@@ -239,15 +239,15 @@ CAMLprim value caml_extunix_readlinkat(value v_dirfd, value v_name)
   CAMLlocal1(v_link);
   int dirfd = Int_val(v_dirfd);
   char* res;
-  char* p = strdup(String_val(v_name));
+  char* p = caml_stat_strdup(String_val(v_name));
 
   caml_enter_blocking_section();
   res = readlinkat_malloc(dirfd, p);
   caml_leave_blocking_section();
-  free(p);
+  caml_stat_free(p);
   if (res == NULL) uerror("readlinkat", v_name);
   v_link = caml_copy_string(res);
-  free(res);
+  caml_stat_free(res);
   CAMLreturn(v_link);
 }
 

--- a/src/fsync.c
+++ b/src/fsync.c
@@ -1,4 +1,3 @@
-
 #define EXTUNIX_WANT_FSYNC
 #define EXTUNIX_WANT_FDATASYNC
 #define EXTUNIX_WANT_SYNC
@@ -39,9 +38,10 @@ CAMLprim value caml_extunix_fdatasync(value v)
 CAMLprim value caml_extunix_fsync(value v_fd)
 {
     CAMLparam1(v_fd);
+    int fd = Int_val(v_fd);
     int r = 0;
     caml_enter_blocking_section();
-    r = fsync(Int_val(v_fd));
+    r = fsync(fd);
     caml_leave_blocking_section();
     if (0 != r)
       uerror("fsync",Nothing);
@@ -53,9 +53,10 @@ CAMLprim value caml_extunix_fsync(value v_fd)
 CAMLprim value caml_extunix_fdatasync(value v_fd)
 {
     CAMLparam1(v_fd);
+    int fd = Int_val(v_fd);
     int r = 0;
     caml_enter_blocking_section();
-    r = fdatasync(Int_val(v_fd));
+    r = fdatasync(fd);
     caml_leave_blocking_section();
     if (0 != r)
       uerror("fdatasync",Nothing);
@@ -78,12 +79,13 @@ CAMLprim value caml_extunix_sync(value v_unit)
 CAMLprim value caml_extunix_syncfs(value v_fd)
 {
     CAMLparam1(v_fd);
+    int fd = Int_val(v_fd);
     int r = 0;
     caml_enter_blocking_section();
 #if defined(EXTUNIX_USE_SYS_SYNCFS)
-    r = syscall(SYS_syncfs, Int_val(v_fd));
+    r = syscall(SYS_syncfs, fd);
 #else
-    r = syncfs(Int_val(v_fd));
+    r = syncfs(fd);
 #endif
     caml_leave_blocking_section();
     if (0 != r)

--- a/src/mktemp.c
+++ b/src/mktemp.c
@@ -9,18 +9,18 @@
 CAMLprim value caml_extunix_mkdtemp(value v_path)
 {
   CAMLparam1(v_path);
-  char* path = strdup(String_val(v_path));
+  char* path = caml_stat_strdup(String_val(v_path));
   char *ret;
   caml_enter_blocking_section();
   ret = mkdtemp(path);
   caml_leave_blocking_section();
   if (NULL == ret)
   {
-    free(path);
+    caml_stat_free(path);
     uerror("mkdtemp", v_path);
   }
   v_path = caml_copy_string(ret);
-  free(path);
+  caml_stat_free(path);
   CAMLreturn(v_path);
 }
 

--- a/src/mount.c
+++ b/src/mount.c
@@ -1,4 +1,3 @@
-
 #define EXTUNIX_WANT_MOUNT
 #include "config.h"
 
@@ -18,10 +17,10 @@ CAMLprim value caml_extunix_mount(value v_source, value v_target,
 {
   CAMLparam5(v_source, v_target, v_fstype, v_mountflags, v_data);
   int ret;
-  char* p_source = strdup(String_val(v_source));
-  char* p_target = strdup(String_val(v_target));
-  char* p_fstype = strdup(String_val(v_fstype));
-  char* p_data   = strdup(String_val(v_data));
+  char* p_source = caml_stat_strdup(String_val(v_source));
+  char* p_target = caml_stat_strdup(String_val(v_target));
+  char* p_fstype = caml_stat_strdup(String_val(v_fstype));
+  char* p_data   = caml_stat_strdup(String_val(v_data));
 
   int p_mountflags = caml_convert_flag_list(v_mountflags, mountflags_table);
 
@@ -29,10 +28,10 @@ CAMLprim value caml_extunix_mount(value v_source, value v_target,
   ret = mount(p_source, p_target, p_fstype, p_mountflags, p_data);
   caml_leave_blocking_section();
 
-  free(p_source);
-  free(p_target);
-  free(p_fstype);
-  free(p_data);
+  caml_stat_free(p_source);
+  caml_stat_free(p_target);
+  caml_stat_free(p_fstype);
+  caml_stat_free(p_data);
 
   if (ret != 0) uerror("mount", v_target);
   CAMLreturn(Val_unit);
@@ -46,7 +45,7 @@ CAMLprim value caml_extunix_umount2(value v_target,value v_umountflags)
 {
   CAMLparam2(v_target, v_umountflags);
   int ret;
-  char* p_target = strdup(String_val(v_target));
+  char* p_target = caml_stat_strdup(String_val(v_target));
 
   int p_umountflags = caml_convert_flag_list(v_umountflags, umountflags_table);
 
@@ -54,7 +53,7 @@ CAMLprim value caml_extunix_umount2(value v_target,value v_umountflags)
   ret = umount2(p_target, p_umountflags);
   caml_leave_blocking_section();
 
-  free(p_target);
+  caml_stat_free(p_target);
 
   if (ret != 0) uerror("umount", v_target);
   CAMLreturn(Val_unit);
@@ -62,4 +61,3 @@ CAMLprim value caml_extunix_umount2(value v_target,value v_umountflags)
 
 
 #endif
-

--- a/src/poll.c
+++ b/src/poll.c
@@ -1,4 +1,3 @@
-
 #define EXTUNIX_WANT_POLL
 #include "config.h"
 
@@ -36,9 +35,7 @@ CAMLprim value caml_extunix_poll(value v_fds, value v_n, value v_ms)
   if (0 == n)
     CAMLreturn(Val_emptylist);
 
-  fd = malloc(n * sizeof(struct pollfd));
-  if (NULL == fd)
-    uerror("malloc",Nothing);
+  fd = caml_stat_alloc(n * sizeof(struct pollfd));
 
   for (i = 0; i < n; i++)
   {
@@ -53,7 +50,7 @@ CAMLprim value caml_extunix_poll(value v_fds, value v_n, value v_ms)
 
   if (result < 0)
   {
-    free(fd);
+    caml_stat_free(fd);
     uerror("poll",Nothing);
   }
 
@@ -72,7 +69,7 @@ CAMLprim value caml_extunix_poll(value v_fds, value v_n, value v_ms)
     }
   }
 
-  free(fd);
+  caml_stat_free(fd);
 
   CAMLreturn(v_l);
 }

--- a/src/sendmsg.c
+++ b/src/sendmsg.c
@@ -54,9 +54,7 @@ CAMLprim value caml_extunix_sendmsg(value fd_val, value sendfd_val, value data_v
   }
 
   datalen = caml_string_length(data_val);
-  buf = malloc(datalen);
-  if (NULL == buf)
-    uerror("sendmsg", Nothing);
+  buf = caml_stat_alloc(datalen);
   memcpy(buf, String_val(data_val), datalen);
 
   iov[0].iov_base = buf;
@@ -68,7 +66,7 @@ CAMLprim value caml_extunix_sendmsg(value fd_val, value sendfd_val, value data_v
   ret = sendmsg(fd, &msg, 0);
   caml_leave_blocking_section();
 
-  free(buf);
+  caml_stat_free(buf);
 
   if (ret == -1)
     uerror("sendmsg", Nothing);

--- a/src/signalfd.c
+++ b/src/signalfd.c
@@ -56,14 +56,15 @@ static struct custom_operations ssi_ops = {
 #define SSI_SIZE sizeof(struct signalfd_siginfo)
 
 CAMLprim
-value caml_extunix_signalfd_read(value vfd)
+value caml_extunix_signalfd_read(value v_fd)
 {
-  CAMLparam1(vfd);
+  CAMLparam1(v_fd);
   CAMLlocal1(vret);
+  int fd = Int_val(v_fd);
   struct signalfd_siginfo ssi;
   ssize_t nread = 0;
   caml_enter_blocking_section();
-  nread = read(Int_val(vfd), &ssi, SSI_SIZE);
+  nread = read(fd, &ssi, SSI_SIZE);
   caml_leave_blocking_section();
   if (nread != SSI_SIZE)
     unix_error(EINVAL,"signalfd_read",Nothing);
@@ -107,4 +108,3 @@ SSI_GET_FIELD( stime   , caml_copy_int64 )
 SSI_GET_FIELD( addr    , caml_copy_int64 )
 
 #endif /* EXTUNIX_HAVE_SIGNALFD */
-

--- a/src/syslog.c
+++ b/src/syslog.c
@@ -1,4 +1,3 @@
-
 #define EXTUNIX_WANT_SYSLOG
 #include "config.h"
 
@@ -60,11 +59,11 @@ CAMLprim value caml_extunix_openlog(value v_ident, value v_option, value v_facil
 
   if (NULL != ident)
   {
-    free(ident);
+    caml_stat_free(ident);
     ident = NULL;
   }
 
-  ident = (Val_none == v_ident) ? NULL : strdup(String_val(Some_val(v_ident)));
+  ident = (Val_none == v_ident) ? NULL : caml_stat_strdup(String_val(Some_val(v_ident)));
   option = caml_convert_flag_list(v_option, option_table);
   index_facility = Int_val(v_facility);
   assert(index_facility < (sizeof(facility_table) / sizeof(int)));
@@ -105,16 +104,15 @@ CAMLprim value caml_extunix_syslog(value v_facility, value v_level, value v_stri
   index_level = Int_val(v_level);
   assert(index_level < (sizeof(level_table) / sizeof(int)));
   level = level_table[index_level];
-  str = strdup(String_val(v_string));
+  str = caml_stat_strdup(String_val(v_string));
 
   caml_enter_blocking_section();
   syslog(level | facility, "%s", str);
   caml_leave_blocking_section();
 
-  free(str);
+  caml_stat_free(str);
 
   CAMLreturn(Val_unit);
 }
 
 #endif
-

--- a/src/unistd.c
+++ b/src/unistd.c
@@ -481,13 +481,13 @@ CAMLprim value caml_extunix_chroot(value v_path)
 {
   CAMLparam1(v_path);
   int ret;
-  char* p_path = strdup(String_val(v_path));
+  char* p_path = caml_stat_strdup(String_val(v_path));
 
   caml_enter_blocking_section();
   ret = chroot(p_path);
   caml_leave_blocking_section();
 
-  free(p_path);
+  caml_stat_free(p_path);
 
   if (ret != 0) uerror("chroot", v_path);
   CAMLreturn(Val_unit);


### PR DESCRIPTION
- Move macros accessing values outside of blocking sections;
- Use `caml_stat_*` functions instead of `malloc`/`free` for heap data.